### PR TITLE
Updated Gulp into v5 + disable encoding on assets copy

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -124,7 +124,9 @@ gulp.task("plugins", () => {
 
 // public files
 gulp.task("public", () => {
-  return gulp.src(path.src.public).pipe(gulp.dest(path.build.dir));
+  return gulp
+    .src(path.src.public, { encoding: false })
+    .pipe(gulp.dest(path.build.dir));
 });
 
 // Clean Theme Folder

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.7",
-    "@tailwindcss/typography": "^0.5.10",
-    "autoprefixer": "^10.4.18",
+    "@tailwindcss/typography": "^0.5.12",
+    "autoprefixer": "^10.4.19",
     "browser-sync": "^3.0.2",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-file-include": "^2.3.0",
     "gulp-header-comment": "^0.10.0",
     "gulp-jshint": "^2.1.0",
@@ -29,11 +29,11 @@
     "gulp-wrapper": "^1.0.0",
     "jshint": "^2.13.6",
     "jshint-stylish": "^2.2.1",
-    "postcss": "^8.4.35",
+    "postcss": "^8.4.38",
     "prettier": "^3.2.5",
-    "prettier-plugin-tailwindcss": "^0.5.11",
-    "sass": "^1.71.1",
+    "prettier-plugin-tailwindcss": "^0.5.13",
+    "sass": "^1.72.0",
     "tailwind-bootstrap-grid": "^5.1.0",
-    "tailwindcss": "^3.4.1"
+    "tailwindcss": "^3.4.3"
   }
 }


### PR DESCRIPTION
Updated package.json with latest Gulp v5. 
also copying png/jpg (binary) files is modifying the content. so disabled encoding on assets copy.